### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information about gSLICr please visit the project website <http://www.r
 
 Other related projects can be found in the Oxford Active Vision Library <http://www.oxvisionlib.org>.
 
-#1. Updates from gSLIC
+# 1. Updates from gSLIC
 - Works for any size / number of super pixels
 - With GTX Titan X, 3.4ms@640x480, 12ms@1280x960, 20ms@1920x1080 image
 - Multi-platform supported
@@ -20,9 +20,9 @@ Other related projects can be found in the Oxford Active Vision Library <http://
   - Ubuntu 14.04
   - Mac OSX 10.10
 
-#2. Building the System
+# 2. Building the System
 
-###2.1 Requirements
+### 2.1 Requirements
 
 Several 3rd party libraries are needed for compiling gSLICr. The given version numbers are checked and working, but different versions might be fine as well. Some of the libraries are optional, and skipping them will reduce functionality.
 
@@ -38,7 +38,7 @@ Several 3rd party libraries are needed for compiling gSLICr. The given version n
     REQUIRED if you want to run the demo, where it is used for reading camera input and displaying UI
     available at http://opencv.org/downloads.html
 
-###2.2 Build Process
+### 2.2 Build Process
 
   To compile the system, use the standard cmake approach:
 ```
@@ -60,7 +60,7 @@ make
 ```
 - press `s` to save current segmentation result to current folder.
 
-#3. What to cite
+# 3. What to cite
 If you use this code for your research, please kindly cite:
 ```
 @article{gSLICr_2015,


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
