### PR TITLE
installation instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,7 @@ SOURCE_GROUP(engines FILES ${GSLICR_LIB})
 
 cuda_add_library(gSLICr_lib
 			${GSLICR_LIB}
-			NVTimer.h
-			OPTIONS -gencode arch=compute_30,code=compute_30)
+			NVTimer.h)
 target_link_libraries(gSLICr_lib ${CUDA_LIBRARY})
 
 add_executable(demo demo.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(gSLICr)
-  
+
+set(CMAKE_CXX_STANDARD 11)
+
 IF(MSVC_IDE)
   set(OpenCV_STATIC OFF)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
@@ -35,7 +37,7 @@ gSLICr_Lib/gSLICr_defines.h
 gSLICr_Lib/gSLICr.h
 )
 
-list(APPEND "-std=c++11 -ftree-vectorize")
+list(APPEND "-ftree-vectorize")
 SOURCE_GROUP(engines FILES ${GSLICR_LIB})
 
 cuda_add_library(gSLICr_lib
@@ -46,3 +48,28 @@ target_link_libraries(gSLICr_lib ${CUDA_LIBRARY})
 
 add_executable(demo demo.cpp)
 target_link_libraries(demo gSLICr_lib ${OpenCV_LIBS})
+
+include(GNUInstallDirs)
+
+# install library
+install(TARGETS gSLICr_lib EXPORT ${PROJECT_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+# install header file hierarchy
+file(GLOB_RECURSE HEADER_FILES RELATIVE ${CMAKE_SOURCE_DIR} *.h)
+foreach(HEADER ${HEADER_FILES})
+    string(REGEX MATCH "(.*)[/\\]" DIR ${HEADER})
+    install(FILES ${HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${DIR})
+endforeach()
+
+target_include_directories(gSLICr_lib PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>/${PROJECT_NAME}/gSLICr_Lib/")
+
+# export library
+install(EXPORT ${PROJECT_NAME}
+    DESTINATION share/${PROJECT_NAME}/cmake
+    FILE ${PROJECT_NAME}Config.cmake
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(gSLICr)
-
-set(CMAKE_CXX_STANDARD 11)
+project(gSLICr LANGUAGES CXX CUDA)
 
 IF(MSVC_IDE)
   set(OpenCV_STATIC OFF)
@@ -16,10 +14,9 @@ if(APPLE)
   set(CUDA_HOST_COMPILER /usr/bin/clang)
 endif(APPLE)
 
-find_package(CUDA REQUIRED)
 find_package(OpenCV REQUIRED)
 
-include_directories(${CUDA_INCLUDE_DIRS})
+include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 include_directories(${OpenCV_INCLUDE_DIRS})
 add_subdirectory(ORUtils)
 
@@ -40,10 +37,13 @@ gSLICr_Lib/gSLICr.h
 list(APPEND "-ftree-vectorize")
 SOURCE_GROUP(engines FILES ${GSLICR_LIB})
 
-cuda_add_library(gSLICr_lib
-			${GSLICR_LIB}
-			NVTimer.h)
+add_library(gSLICr_lib ${GSLICR_LIB} NVTimer.h)
 target_link_libraries(gSLICr_lib ${CUDA_LIBRARY})
+target_compile_features(gSLICr_lib PUBLIC cxx_std_11)
+set_target_properties(gSLICr_lib
+  PROPERTIES CUDA_SEPARABLE_COMPILATION ON
+  POSITION_INDEPENDENT_CODE ON
+)
 
 add_executable(demo demo.cpp)
 target_link_libraries(demo gSLICr_lib ${OpenCV_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 project(gSLICr)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/ORUtils/CMakeLists.txt
+++ b/ORUtils/CMakeLists.txt
@@ -38,7 +38,7 @@ SOURCE_GROUP("" FILES ${ORUTILS_HEADERS})
 add_library(ORUtils ${ORUTILS_OBJECTS})
 
 IF(WITH_CUDA)
-#  include_directories(${CUDA_INCLUDE_DIRS})
+#  include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 #  cuda_add_library(ITMLib
 #	${ITMLIB_CPU_OBJECTS}
 #	${ITMLIB_CUDA_OBJECTS}

--- a/gSLICr_Lib/engines/gSLICr_seg_engine.cpp
+++ b/gSLICr_Lib/engines/gSLICr_seg_engine.cpp
@@ -38,7 +38,7 @@ void seg_engine::Perform_Segmentation(UChar4Image* in_img)
 	}
 
 	if(gSLICr_settings.do_enforce_connectivity) Enforce_Connectivity();
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 }
 
 

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>gslicr</name>
+  <version>0.0.0</version>
+  <description>This is the software bundle "gSLICr", a library for real-time superpixel segmentation written in C++ and CUDA.</description>
+
+  <maintainer email="Christian.Rauch@ed.ac.uk">Christian Rauch</maintainer>
+
+  <license>TODO</license>
+
+  <url type="repository">https://github.com/carlren/gSLICr</url>
+  <url type="website">https://arxiv.org/abs/1509.04232</url>
+
+  <author email="carl@robots.ox.ac.uk">Carl Yuheng Ren</author>
+  <author email="victor@robots.ox.ac.uk">Victor Adrian Prisacariu</author>
+  <author email="ian.reid@adelaide.edu.au">Ian D Reid</author>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <depend>libopencv-dev</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This is the same as https://github.com/carlren/gSLICr/pull/26 with a different branch name. The previous PR was closed automatically after the branch was renamed.

This adds a catkin/colcon metainfo file and installation instructions to the CMake file such that this repo can be used in a catkin/colcon workspace. It does not add any new dependencies.